### PR TITLE
feat(typography): add shadcn-style typography components and migrate pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
+    "@tailwindcss/typography": "0.5.19",
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.4
+      '@tailwindcss/typography':
+        specifier: 0.5.19
+        version: 0.5.19(tailwindcss@4.2.4)
       '@types/node':
         specifier: ^25
         version: 25.6.1
@@ -978,6 +981,11 @@ packages:
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1445,6 +1453,11 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2467,6 +2480,10 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2848,6 +2865,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -3650,6 +3670,11 @@ snapshots:
       postcss: 8.5.14
       tailwindcss: 4.2.4
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.2.4)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.4
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -4072,6 +4097,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -5356,6 +5383,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
@@ -5877,6 +5909,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:
       react: 19.2.6
+
+  util-deprecate@1.0.2: {}
 
   vfile-message@4.0.3:
     dependencies:

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { H1, Lead } from '@/components/typography';
 import Socials from '@/components/socials';
 import { siteConfig } from '@/config/site';
 
@@ -17,26 +18,26 @@ export default function About() {
         <Badge variant="outline" className="mb-4">
           About Me
         </Badge>
-        <h1 className="text-4xl font-bold mb-6">{siteConfig.author.name}</h1>
+        <H1 className="mb-6">{siteConfig.author.name}</H1>
 
         <div className="grid md:grid-cols-2 gap-8">
           <div>
-            <p className="text-lg text-muted-foreground mb-4">
+            <Lead className="mb-4">
               Hey! I&apos;m a proud{' '}
               <span className="font-medium">IIT Patna CSE &apos;24</span>{' '}
               graduate. I focus on full-stack development, Web3, and competitive
               programming.
-            </p>
-            <p className="text-lg text-muted-foreground mb-4">
+            </Lead>
+            <Lead className="mb-4">
               Outside of coding, you&apos;ll find me on the football field or
               shooting hoops. I&apos;m also a huge movie enthusiast—whether
               it&apos;s action-packed blockbusters or thought-provoking dramas.
-            </p>
-            <p className="text-lg text-muted-foreground mb-6">
+            </Lead>
+            <Lead className="mb-6">
               Originally from <span className="font-medium">Nashik</span>,
               I&apos;m always excited about creating new tech and exploring the
               world of open-source.
-            </p>
+            </Lead>
             <Socials />
           </div>
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,18 +1,17 @@
 import ContactForm from '@/components/contact/contact-form';
+import { H1, Lead } from '@/components/typography';
 
 function Contact() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8">
       <div className="w-full max-w-4xl mx-auto space-y-8">
         <div className="text-center space-y-4">
-          <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            Get in Touch
-          </h1>
-          <p className="text-muted-foreground max-w-2xl mx-auto text-lg">
+          <H1>Get in Touch</H1>
+          <Lead className="max-w-2xl mx-auto">
             Have a question or want to work together? I&apos;d love to hear from
             you. Fill out the form below and I&apos;ll get back to you as soon
             as possible.
-          </p>
+          </Lead>
         </div>
 
         <div className="mt-8">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { H1, H2, H3, List, Muted, P } from '@/components/typography';
 import Link from 'next/link';
 import { siteConfig } from '@/config/site';
 
@@ -9,47 +10,37 @@ export default function PrivacyPage() {
     <section className="mt-8 pb-16 max-w-3xl mx-auto px-4 sm:px-8">
       {/* Header Section */}
       <div className="space-y-4 mb-8">
-        <h1 className="text-5xl font-bold dark:text-gray-100">
-          Privacy Policy
-        </h1>
-        <p className="dark:text-gray-400">Last Updated: {lastUpdated}</p>
+        <H1>Privacy Policy</H1>
+        <Muted>Last Updated: {lastUpdated}</Muted>
       </div>
 
       {/* Main Content */}
       <div className="space-y-8">
-        <h2 className="text-3xl font-semibold dark:text-gray-200">Welcome!</h2>
-        <p className="dark:text-gray-300">
+        <H2>Welcome!</H2>
+        <P>
           Thanks for stopping by! This <b>Privacy Policy</b> explains how things
           work here. Spoiler alert: my site is mainly a showcase for my work,
           and your privacy is a big deal—just not a huge one since I don&apos;t
           collect much.
-        </p>
+        </P>
 
-        <h2 className="text-3xl font-semibold dark:text-gray-200">
-          Information I Collect (Spoiler: It&apos;s Not Much)
-        </h2>
-        <p className="dark:text-gray-300">
+        <H2>Information I Collect (Spoiler: It&apos;s Not Much)</H2>
+        <P>
           Given that this is a static portfolio, I don&apos;t collect any
           personal data. That means no account creation, no tracking cookies,
           and definitely no hidden data collection—sounds like a dream, right?
-        </p>
+        </P>
 
-        <h3 className="text-2xl font-semibold dark:text-gray-200">
-          Contact Information
-        </h3>
-        <p className="dark:text-gray-300">
+        <H3>Contact Information</H3>
+        <P>
           If you decide to drop me a line via email or the form, it&apos;s
           entirely up to you what information you share. I promise to use it
           solely to respond to your message—nothing more, nothing less.
-        </p>
+        </P>
 
-        <h2 className="text-3xl font-semibold dark:text-gray-200">
-          How I Use the Information
-        </h2>
-        <p className="dark:text-gray-300">
-          If I do receive any info, here&apos;s what I might do with it:
-        </p>
-        <ul className="list-disc pl-5 space-y-2 dark:text-gray-300">
+        <H2>How I Use the Information</H2>
+        <P>If I do receive any info, here&apos;s what I might do with it:</P>
+        <List>
           <li>Make sure the website is running smoothly</li>
           <li>
             Improve the site based on your feedback (yes, I actually care)
@@ -58,63 +49,51 @@ export default function PrivacyPage() {
             Respond to your inquiries or feedback—because that&apos;s what
             polite people do
           </li>
-        </ul>
+        </List>
 
-        <h2 className="text-3xl font-semibold dark:text-gray-200">
-          Sharing Information (I Don&apos;t)
-        </h2>
-        <p className="dark:text-gray-300">
+        <H2>Sharing Information (I Don&apos;t)</H2>
+        <P>
           I don&apos;t sell, trade, or share your personal data. If you
           accidentally share any sensitive information, just let me know, and
           I&apos;ll help you get rid of it faster than you can say “privacy
           breach.”
-        </p>
+        </P>
 
-        <h2 className="text-3xl font-semibold dark:text-gray-200">
-          Security (No System Is Perfect)
-        </h2>
-        <p className="dark:text-gray-300">
+        <H2>Security (No System Is Perfect)</H2>
+        <P>
           While I do my best to keep your data secure, no system is flawless.
           I&apos;ll take reasonable steps to protect any shared info, but I
           can&apos;t guarantee absolute security—after all, I&apos;m not a
           magician.
-        </p>
+        </P>
 
-        <h2 className="text-3xl font-semibold dark:text-gray-200">
-          Third-Party Links (Not My Circus, Not My Monkeys)
-        </h2>
-        <p className="dark:text-gray-300">
+        <H2>Third-Party Links (Not My Circus, Not My Monkeys)</H2>
+        <P>
           My portfolio may contain links to other sites. I&apos;m not
           responsible for their privacy practices or content, so proceed with
           caution and read their policies too!
-        </p>
+        </P>
 
-        <h2 className="text-3xl font-semibold dark:text-gray-200">
-          Your Rights (Because You Should Know)
-        </h2>
-        <p className="dark:text-gray-300">
+        <H2>Your Rights (Because You Should Know)</H2>
+        <P>
           If you ever provide me with any personal information, you have the
           right to request access to it, ask for corrections, or request
           deletion. Just let me know, and I&apos;ll be happy to help—unless I
           can&apos;t find it, then we&apos;ll just chalk it up to the mysteries
           of the internet.
-        </p>
+        </P>
 
-        <h2 className="text-3xl font-semibold dark:text-gray-200">
-          Policy Updates (Keeping You Informed)
-        </h2>
-        <p className="dark:text-gray-300">
+        <H2>Policy Updates (Keeping You Informed)</H2>
+        <P>
           This policy is current as of <b>{lastUpdated}</b>. If anything
           changes, I&apos;ll update this page. Feel free to check back, but
           don&apos;t worry—I&apos;ll notify you if anything major happens. No
           surprise changes here!
-        </p>
+        </P>
 
         {/* Contact Section with Button */}
-        <h2 className="text-3xl font-semibold dark:text-gray-200">
-          Have Questions?
-        </h2>
-        <p className="dark:text-gray-300 pb-2">
+        <H2>Have Questions?</H2>
+        <P>
           Got any questions, concerns, or just feel like saying hello? You can
           email me at{' '}
           <Link
@@ -131,7 +110,7 @@ export default function PrivacyPage() {
             contact form
           </Link>
           .
-        </p>
+        </P>
 
         <Link href="/contact">
           <Button className="mt-4">Contact Me</Button>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,9 +1,10 @@
 import Projects from '@/components/project';
+import { H1 } from '@/components/typography';
 
 export default function ProjectsPage() {
   return (
     <div className="mt-8 flex flex-col gap-8 pb-16">
-      <h1 className="text-3xl font-bold">My projects</h1>
+      <H1>My projects</H1>
       <Projects />
     </div>
   );

--- a/src/components/home/home.tsx
+++ b/src/components/home/home.tsx
@@ -7,6 +7,7 @@ import ResumeButton from '@/components/resume-button';
 import Timeline from '../timeline';
 import { Separator } from '../ui/separator';
 import { Badge } from '../ui/badge';
+import { H1, H2 } from '@/components/typography';
 import { siteConfig } from '@/config/site';
 
 export default function Home() {
@@ -33,9 +34,9 @@ export default function Home() {
 
           <div className="flex flex-col items-center md:items-start gap-4">
             <div className="flex flex-col gap-2">
-              <h1 className="text-3xl md:text-4xl font-bold text-gradient">
+              <H1 className="text-3xl md:text-4xl text-gradient">
                 Hey, I&apos;m {siteConfig.author.name}
-              </h1>
+              </H1>
               <div className="mt-1 gap-2">
                 <Badge variant="outline">{siteConfig.author.role}</Badge>
               </div>
@@ -78,9 +79,7 @@ export default function Home() {
       <section>
         <section className="mb-8">
           <div>
-            <h2 className="text-2xl font-bold mb-6 border-b-2 pb-2">
-              Education & Experience
-            </h2>
+            <H2 className="mb-6">Education & Experience</H2>
             <Timeline />
           </div>
         </section>
@@ -89,7 +88,7 @@ export default function Home() {
       {/* Project Section */}
       <section className="flex flex-col gap-8">
         <div className="flex justify-between items-center border-b-2 pb-3">
-          <h2 className="text-2xl font-bold">Featured projects</h2>
+          <H2 className="border-b-0 pb-0">Featured projects</H2>
           <Link href="/projects" className="link flex items-center gap-2">
             <span>view more</span>
             <ArrowRightIcon className="size-5 cursor-pointer animate-pulse" />

--- a/src/components/typography/index.tsx
+++ b/src/components/typography/index.tsx
@@ -1,0 +1,132 @@
+/**
+ * Typography primitives mirrored from the shadcn/ui new-york docs:
+ * https://ui.shadcn.com/docs/components/radix/typography
+ *
+ * Each component is a styled element that forwards `className` through `cn()`,
+ * so consumers can override or extend (tailwind-merge resolves conflicts).
+ *
+ * Deviation from shadcn: H1 drops `text-center` from the default — left-aligned
+ * is the right default inside flowing content. Pass `className="text-center"`
+ * at the call site when you need it.
+ */
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export function H1({ className, ...props }: React.ComponentProps<'h1'>) {
+  return (
+    <h1
+      className={cn(
+        'scroll-m-20 text-4xl font-extrabold tracking-tight text-balance',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function H2({ className, ...props }: React.ComponentProps<'h2'>) {
+  return (
+    <h2
+      className={cn(
+        'scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function H3({ className, ...props }: React.ComponentProps<'h3'>) {
+  return (
+    <h3
+      className={cn(
+        'scroll-m-20 text-2xl font-semibold tracking-tight',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function H4({ className, ...props }: React.ComponentProps<'h4'>) {
+  return (
+    <h4
+      className={cn(
+        'scroll-m-20 text-xl font-semibold tracking-tight',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function P({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <p
+      className={cn('leading-7 [&:not(:first-child)]:mt-6', className)}
+      {...props}
+    />
+  );
+}
+
+export function Blockquote({
+  className,
+  ...props
+}: React.ComponentProps<'blockquote'>) {
+  return (
+    <blockquote
+      className={cn('mt-6 border-l-2 pl-6 italic', className)}
+      {...props}
+    />
+  );
+}
+
+export function List({ className, ...props }: React.ComponentProps<'ul'>) {
+  return (
+    <ul
+      className={cn('my-6 ml-6 list-disc [&>li]:mt-2', className)}
+      {...props}
+    />
+  );
+}
+
+export function InlineCode({
+  className,
+  ...props
+}: React.ComponentProps<'code'>) {
+  return (
+    <code
+      className={cn(
+        'bg-muted relative rounded px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function Lead({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <p className={cn('text-muted-foreground text-xl', className)} {...props} />
+  );
+}
+
+export function Large({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div className={cn('text-lg font-semibold', className)} {...props} />;
+}
+
+export function Small({ className, ...props }: React.ComponentProps<'small'>) {
+  return (
+    <small
+      className={cn('text-sm leading-none font-medium', className)}
+      {...props}
+    />
+  );
+}
+
+export function Muted({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <p className={cn('text-muted-foreground text-sm', className)} {...props} />
+  );
+}


### PR DESCRIPTION
## Summary

Introduces a shared typography module mirroring the [shadcn/ui new-york docs](https://ui.shadcn.com/docs/components/radix/typography) and migrates all five user-facing pages off ad-hoc Tailwind heading/paragraph classes.

## What changed

- **Plugin** — installs \`@tailwindcss/typography\` and registers it via Tailwind v4's CSS-first \`@plugin\` directive in \`globals.css\`. The \`prose ... dark:prose-invert\` classes already present in \`project-card.tsx\` and \`timeline-item.tsx\` (previously no-ops because the plugin wasn't installed) now actually emit styles.
- **Components** — \`src/components/typography/index.tsx\` exports \`H1\`, \`H2\`, \`H3\`, \`H4\`, \`P\`, \`Blockquote\`, \`List\`, \`InlineCode\`, \`Lead\`, \`Large\`, \`Small\`, \`Muted\`. Each forwards \`className\` through \`cn()\` so consumers can override per call (\`tailwind-merge\` resolves conflicts).
- **One deviation from the docs:** \`H1\` drops \`text-center\` from the default — left-aligned is the right default inside flowing content.
- **Page migrations** — \`/privacy\`, \`/\`, \`/about\`, \`/contact\`, \`/projects\` all replace bespoke heading/paragraph classes with the new components. Each page is its own commit.

## Why this matters

- **\`/privacy\` was the worst offender.** Sixteen sections used hardcoded \`dark:text-gray-100\` / \`gray-200\` / \`gray-300\` / \`gray-400\` instead of the design tokens. Light mode read default black, dark mode ignored \`--foreground\` / \`--muted-foreground\`. Now fully token-driven.
- **Inconsistency.** Heading sizes drifted (\`text-3xl\` / \`4xl\` / \`5xl\` for h1 across pages) with no system. One file, one source of truth now.
- **Markdown rendering.** \`/projects\` shows nine project descriptions wrapped in \`prose\`. Without the plugin those classes did nothing — paragraphs and lists collapsed against each other. Now correctly spaced.

## Visual changes (intentional, accept shadcn defaults)

- H1 across all pages: \`text-4xl font-extrabold\` (was a mix of \`font-bold\` and various sizes). Hero on \`/\` keeps responsive override (\`text-3xl md:text-4xl\`) and \`text-gradient\`.
- About page intro paragraphs: \`text-lg\` → \`text-xl\` (now \`Lead\` semantic).
- Section h2s on \`/\`: \`text-2xl font-bold\` → \`text-3xl font-semibold\`. \"Featured projects\" h2 keeps borderless via \`border-b-0\` since parent provides the rule.

## Verification

- ✅ \`pnpm lint\` clean
- ✅ \`pnpm exec tsc --noEmit\` clean
- ✅ \`pnpm build\` clean — CSS bundle confirmed shipping \`.prose\` selectors (\`grep -o 'prose[a-zA-Z-]*' .next/static/chunks/*.css\` returns 60+ unique prose classes)
- ✅ Smoke-tested all five pages via Next.js DevTools MCP browser automation:
  - \`/privacy\`: light mode reads \`--foreground\` (\`rgb(9,9,11)\`); dark mode reads \`rgb(250,250,250)\` over \`rgb(9,9,11)\` — token-driven, no leftover greys
  - \`/\`: hero \`text-gradient\` working, h2 borders correct
  - \`/about\`: h1 36px/800, three \`Lead\` paragraphs at text-xl muted
  - \`/contact\`: h1 inherits parent \`text-center\`, \`Lead\` with max-w override
  - \`/projects\`: nine \`.prose\` elements now styled (was 0 before plugin)

## Out of scope (flagged for follow-up)

- **Duplicate React key warning on \`/projects\`** — \`src/data/projects.json\` has \`https://github.com/KartikMouli/ChatApp\` as \`href\` on two different projects (lines 116 & 162). Pre-existing data issue, unrelated to this refactor.
- **Blue inline links on \`/privacy\`** still use \`text-blue-500 underline hover:text-blue-300\` instead of \`text-primary\`. Separate concern.

## Commits

\`\`\`
feat(deps): add @tailwindcss/typography plugin
feat(typography): add shadcn-style typography components
refactor(privacy): use typography components
refactor(home): use typography components
refactor(about): use typography components
refactor(contact): use typography components
refactor(projects): use typography components
\`\`\`