### PR TITLE
fix(rss): emit full post body as HTML in <content:encoded>

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "framer-motion": "12.38.0",
     "github-slugger": "2.0.0",
     "lucide-react": "^0.555.0",
+    "marked": "18.0.3",
     "mermaid": "11.14.0",
     "motion": "12.38.0",
     "next": "16.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       lucide-react:
         specifier: ^0.555.0
         version: 0.555.0(react@19.2.6)
+      marked:
+        specifier: 18.0.3
+        version: 18.0.3
       mermaid:
         specifier: 11.14.0
         version: 11.14.0
@@ -3504,6 +3507,11 @@ packages:
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@18.0.3:
+    resolution: {integrity: sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -8248,6 +8256,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
+
+  marked@18.0.3: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,27 +1,41 @@
+import { marked } from 'marked';
+
 import { siteConfig } from '@/config/site';
-import { getAllPostMetas } from '@/lib/data/blog';
+import { getAllPostMetas, getPostBody } from '@/lib/data/blog';
+
+// GFM is on by default in marked v15+, but pinned explicitly so a
+// future major isn't a silent regression for posts that use tables /
+// task lists / strikethrough. `breaks: false` matches CommonMark — a
+// single newline inside a paragraph is whitespace, not <br>.
+marked.use({ gfm: true, breaks: false });
 
 /**
  * RSS 2.0 feed for the blog at `/feed.xml`.
  *
  * Cross-posting model: this is what dev.to's "publish via RSS"
- * feature subscribes to. dev.to imports each `<item>` as an unpublished
- * draft, copying the canonical URL into its `canonical_url` field
- * automatically — your portfolio stays the canonical source for
- * search engines while reaching dev.to's audience.
+ * feature subscribes to. dev.to imports each `<item>` as an
+ * unpublished draft and uses the `<link>` element as `canonical_url`
+ * (when "Mark the RSS source as canonical URL by default" is enabled
+ * in their RSS settings) — your portfolio stays the canonical source
+ * for search engines while reaching dev.to's audience.
  *
- * Medium dropped auto-RSS imports for new accounts, so cross-posts
- * there are still a manual paste; this feed remains useful for any
- * generic RSS reader.
+ * dev.to's content-element priority is documented as
+ *   1. `<content>` (Atom)
+ *   2. `<summary>` (Atom)
+ *   3. `<description>` (RSS)
+ *   ...with `<content:encoded>` recognised as a separate HTML body.
+ * They convert HTML → Markdown for storage; raw markdown shoved into
+ * `<content:encoded>` would render as a literal-text paragraph, so
+ * we compile each post's body through `marked` before emitting.
+ *
+ * Spec: https://www.rssboard.org/rss-specification · RSS Content
+ * module: http://web.resource.org/rss/1.0/modules/content/ · dev.to
+ * import guide: https://dev.to/p/publishing_from_rss_guide.
  *
  * Drafts are filtered out by `getAllPostMetas` so subscribers never
  * see in-progress writing.
- *
- * Spec: https://www.rssboard.org/rss-specification
- * Atom self-link: included via `xmlns:atom` so feed validators stop
- * complaining about missing autodiscovery.
  */
-export function GET() {
+export async function GET() {
   const url = siteConfig.url;
   const posts = getAllPostMetas();
   const lastBuildDate = new Date().toUTCString();
@@ -30,29 +44,46 @@ export function GET() {
       ? new Date(posts[0]!.publishedAt).toUTCString()
       : lastBuildDate;
 
-  const items = posts
-    .map((post) => {
-      const link = `${url}/blog/${post.slug}`;
-      const pubDate = post.publishedAt
-        ? new Date(post.publishedAt).toUTCString()
-        : lastBuildDate;
-      const categories = post.tags
-        .map((t) => `<category>${escapeXml(t)}</category>`)
-        .join('');
-      return `    <item>
+  const items = (
+    await Promise.all(
+      posts.map(async (post) => {
+        const link = `${url}/blog/${post.slug}`;
+        const pubDate = post.publishedAt
+          ? new Date(post.publishedAt).toUTCString()
+          : lastBuildDate;
+        const categories = post.tags
+          .map((t) => `<category>${escapeXml(t)}</category>`)
+          .join('');
+        // Compile the post body to HTML before emitting. dev.to's
+        // RSS importer reads `<content:encoded>` as HTML and converts
+        // it to Markdown for storage — sending raw markdown here
+        // would land as a single literal-text paragraph instead of
+        // a structured post.
+        //
+        // CDATA-wrap so HTML's `<` / `&` survive the XML parse
+        // verbatim; the `]]>` escape splits any literal close-CDATA
+        // token in user prose so the section stays valid XML.
+        const html = await marked.parse(getPostBody(post.slug));
+        const safeHtml = html.replace(/\]\]>/g, ']]]]><![CDATA[>');
+        return `    <item>
       <title>${escapeXml(post.title)}</title>
       <link>${link}</link>
       <guid isPermaLink="true">${link}</guid>
       <description>${escapeXml(post.summary)}</description>
+      <content:encoded><![CDATA[${safeHtml}]]></content:encoded>
       <pubDate>${pubDate}</pubDate>
       <author>${siteConfig.author.email} (${escapeXml(siteConfig.author.name)})</author>
       ${categories}
     </item>`;
-    })
-    .join('\n');
+      })
+    )
+  ).join('\n');
 
+  // `xmlns:content` declares the RSS Content module so we can emit
+  // `<content:encoded>` on each item. Standard module since 2002,
+  // recognised by every mature feed reader + dev.to / Medium import.
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>${escapeXml(siteConfig.author.name)} — Writing</title>
     <link>${url}/blog</link>

--- a/src/lib/data/blog.ts
+++ b/src/lib/data/blog.ts
@@ -171,6 +171,24 @@ function readPostSource(slug: string): string | null {
 }
 
 /**
+ * Returns the post body (everything after the closing frontmatter
+ * fence) as raw markdown/MDX. Used by the RSS feed to populate
+ * `<content:encoded>` so dev.to / Medium / generic feed readers
+ * receive the full post text rather than just the summary.
+ *
+ * Most posts are pure markdown — dev.to renders that fine. The few
+ * MDX-only constructs (e.g. our `<Mermaid>` block) won't render on
+ * dev.to but degrade gracefully to a fenced code block (which is
+ * how the source author wrote them anyway).
+ */
+export function getPostBody(slug: string): string {
+  const raw = readPostSource(slug);
+  if (!raw) return '';
+  const fm = /^---\n[\s\S]*?\n---\n/.exec(raw);
+  return fm ? raw.slice(fm[0].length).trimStart() : raw;
+}
+
+/**
  * Every distinct tag in the published post set, sorted by frequency
  * desc then alphabetical. Used by the `/blog` tag filter.
  */


### PR DESCRIPTION
## Why

Cross-posting from `/feed.xml` was only delivering the post **summary** to dev.to / RSS readers, not the full body. On dev.to the imported post showed only the title, tag, and one-line summary — nothing else.

## What

The feed was emitting only `<description>` (the summary). Per dev.to's [Publishing from RSS guide](https://dev.to/p/publishing_from_rss_guide), their importer reads the post body from `<content:encoded>` (or the Atom-equivalents `<content>` / `<summary>`) and converts that HTML to Markdown for storage. Without `<content:encoded>` it falls back to `<description>` — hence the summary-only output.

This PR:

1. Adds a `getPostBody(slug)` helper to [`src/lib/data/blog.ts`](src/lib/data/blog.ts) — returns everything after the closing frontmatter fence.
2. Compiles each post body to HTML via `marked` (sync, GFM-on, ~30 KB) before emitting — dev.to expects HTML in `<content:encoded>`; raw markdown would land as a literal-text paragraph.
3. Adds the [RSS Content module](http://web.resource.org/rss/1.0/modules/content/) namespace (`xmlns:content="http://purl.org/rss/1.0/modules/content/"`) to the `<rss>` root and emits `<content:encoded><![CDATA[...]]></content:encoded>` per item.
4. CDATA-wraps the HTML so markdown-special chars survive verbatim; defensive split of any literal `]]>` token in user prose so the section stays valid XML.

## Sample output

```xml
<content:encoded><![CDATA[<p>A short note on what this is.</p>
<h2>What to expect</h2>
<ul>
  <li>short posts on what I'm shipping at work and on side projects</li>
  ...
</ul>
<pre><code class="language-mermaid">flowchart LR
    Idea[Idea] --&gt; Notes[notes.md]
    ...
</code></pre>
]]></content:encoded>
```

`class="language-*"` hints carry through so dev.to's syntax highlighter picks up the right language per fence.

## Verification

- `pnpm build` — clean (29 pages)
- `pnpm lint` — clean
- Locally curled `/feed.xml` — full HTML body present in `<content:encoded>`, summary still in `<description>`.

After merging + deploying, dev.to's RSS poll picks this up automatically (configured at Settings → Extensions → "Publish from RSS"). New imports land with the full article body instead of one-liner stubs.
